### PR TITLE
Add related repo to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # buildpack-registry.js
+
 Node.js/TypeScript library for interacting with the [Heroku Buildpack Registry](https://devcenter.heroku.com/articles/buildpack-registry).

--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
 # buildpack-registry.js
 
 Node.js/TypeScript library for interacting with the [Heroku Buildpack Registry](https://devcenter.heroku.com/articles/buildpack-registry).
+
+## Related
+
+If you are looking for the heroku CLI plugin:
+
+```
+$ heroku plugins:install @heroku-cli/plugin-buildpack-registry
+```
+
+It is at a different (private) repo [`@heroku-cli/plugin-buildpack-registry`](https://github.com/heroku/plugin-buildpack-registry). That plugin uses this library to interact with the buildpack registry.


### PR DESCRIPTION
I was trying to fix a warning in the plugin

```
$ heroku plugins:install @heroku-cli/plugin-buildpack-registry
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: '@heroku-cli/plugin-buildpack-registry@2.0.0',
npm warn EBADENGINE   required: { node: '>=20 <22.18' },
npm warn EBADENGINE   current: { node: 'v22.22.2', npm: '10.9.6' }
npm warn EBADENGINE }
up to date in 262ms
heroku: Installing plugin buildpack-registry@latest... installed v2.0.0
```

It was unclear where it lived. This repo's README was what came up in search. Adding a link so anyone else looking for the same repo would be directed to the right location.