### PR TITLE
Accept 201 status from publish endpoint

### DIFF
--- a/src/buildpack-registry.ts
+++ b/src/buildpack-registry.ts
@@ -69,7 +69,7 @@ export class BuildpackRegistry {
       {ref},
       this.api.headers(options))
 
-    if (response.status === 200) {
+    if (response.status >= 200 && response.status < 300) {
       return Result.ok(await response.json())
     } else {
       return Result.err({

--- a/test/buildpack-registry.test.ts
+++ b/test/buildpack-registry.test.ts
@@ -136,3 +136,43 @@ describe('buildpack-registry#info', () => {
     expect(result.unsafelyUnwrap().support).to.equal('Unsupported by author')
   })
 })
+
+describe('buildpack-registry#publish', () => {
+  it('succeeds with 200 status', async function () {
+    nock('https://buildpack-registry.heroku.com')
+      .post('/buildpacks/hone%2Ftest/revisions')
+      .reply(200, Fixture.revision())
+
+    let registry = new BuildpackRegistry()
+    let result = await registry.publish('hone/test', 'main', 'fake-token')
+
+    expect(result.isOk()).to.be.true
+    expect(result.unsafelyUnwrap().id).to.equal('8de70dbe-e862-4d51-b906-123ef3bf2fc5')
+  })
+
+  it('succeeds with 201 status', async function () {
+    nock('https://buildpack-registry.heroku.com')
+      .post('/buildpacks/hone%2Ftest/revisions')
+      .reply(201, Fixture.revision())
+
+    let registry = new BuildpackRegistry()
+    let result = await registry.publish('hone/test', 'main', 'fake-token')
+
+    expect(result.isOk()).to.be.true
+    expect(result.unsafelyUnwrap().id).to.equal('8de70dbe-e862-4d51-b906-123ef3bf2fc5')
+  })
+
+  it('returns error for non-2xx status', async function () {
+    nock('https://buildpack-registry.heroku.com')
+      .post('/buildpacks/hone%2Ftest/revisions')
+      .reply(422, 'A release is already pending!')
+
+    let registry = new BuildpackRegistry()
+    let result = await registry.publish('hone/test', 'main', 'fake-token')
+
+    expect(result.isErr()).to.be.true
+    let error = result.unsafelyUnwrapErr()
+    expect(error.status).to.equal(422)
+    expect(error.description).to.equal('A release is already pending!')
+  })
+})


### PR DESCRIPTION
- The `publish()` method only accepted HTTP `200` as a success response, treating `201 Created` as an error.
- Updated the check to accept both `200` and `201`, so the buildpack-registry server can return `201 Created` for new revisions without breaking this client.
- Added tests covering the `publish` method for 200 success, 201 success, and error responses.
