### PR TITLE
fix: repair broken 1.0.2 tarball (dist layout + missing tslib dep, fixes heroku/cli#3810)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "node-fetch": "^2.2.0",
-        "true-myth": "^2.0.0"
+        "true-myth": "^2.0.0",
+        "tslib": "^2.8.1"
       },
       "devDependencies": {
         "@types/node": "^20.14.8",
@@ -2960,9 +2961,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
   },
   "dependencies": {
     "node-fetch": "^2.2.0",
-    "true-myth": "^2.0.0"
+    "true-myth": "^2.0.0",
+    "tslib": "^2.8.1"
   },
   "engines": {
     "node": ">= 20"

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,5 +9,3 @@ export {
   RevisionBody,
   RevisionStatus,
 } from './buildpack-registry'
-
-export {Fixture} from '../test/helpers/fixture'


### PR DESCRIPTION
## Summary

Published `@heroku/buildpack-registry@1.0.2` crashes at import time. Two distinct bugs, both surfacing as `MODULE_NOT_FOUND` when a consumer (e.g. `heroku buildpacks` in the CLI, see [heroku/cli#3810](https://github.com/heroku/cli/issues/3810)) does `require('@heroku/buildpack-registry')`:

**Bug 1 — dist/ layout mismatch (fixed in [1b29e1b](https://github.com/heroku/buildpack-registry.js/commit/1b29e1b))**

`package.json` declares `"main": "dist/index.js"`, but the tarball actually contains `dist/src/index.js` — plus `dist/test/helpers/fixture.js` leaked in alongside it. Root cause is a single line in `src/index.ts`:

```ts
export {Fixture} from '../test/helpers/fixture'
```

The `../test/...` path walks outside `src/`. `tsconfig.json` doesn't set `rootDir`, so `tsc` infers it from the widest input path — the repo root — and every emitted file gains an extra `dist/src/` or `dist/test/` prefix. Meanwhile `main` was never updated to match.

The `Fixture` export was originally added in [69ca419](https://github.com/heroku/buildpack-registry.js/commit/69ca419de8a6455f271590e68f4908748f0aaa55) (2018) for external test-writers, back when the helper lived at `src/test/helpers/fixture.ts` and everything stayed inside `src/`. The 2026-03 Dependabot cleanup ([#29](https://github.com/heroku/buildpack-registry.js/pull/29), [26acde4](https://github.com/heroku/buildpack-registry.js/commit/26acde4eb37df726ad9b6c0079e1c8baa869f18d)) moved the file to the top-level `test/` directory but kept the re-export, changing its path to `../test/helpers/fixture` — which is what quietly broke the emitted layout. Version 1.0.2 was the first release since 2018, so the bug sat latent for three months until the CLI picked it up.

`Fixture` is a test helper by name and shape and has no known external consumers, so this PR drops the re-export. Internal tests import it directly from `./helpers/fixture` and are unaffected.

**Bug 2 — missing `tslib` runtime dep (fixed in [78b177e](https://github.com/heroku/buildpack-registry.js/commit/78b177e))**

`tsconfig.json` sets `importHelpers: true`, so `tsc` emits `require("tslib")` in the compiled output — `src/buildpack-registry-api.ts` imports a default+named binding from a CJS module, which triggers a `tslib.__importStar` call. `tslib` was only present in the lockfile as a transitive devDependency, so a fresh consumer install can miss it and hit `MODULE_NOT_FOUND: 'tslib'` when the package is required. This has been latent since 1.0.1; it only became visible once bug 1 was fixed and `dist/index.js` was reachable at all.

## Type of Change
### Patch Updates (patch semver update)
- [x] **fix**: Bug fix

## Testing
**Notes**: The behavior change is in the emitted `dist/` layout and in what a Node consumer sees when they `require()` the package. Reproduce on `master` first — steps 2, 3, and 5 will all fail there — then re-run on this branch to confirm the fix.

**Steps**:
1. `rm -rf dist && npm run prepare`
2. `ls dist/index.js` — file exists at the top level (not `dist/src/index.js`).
3. `npm pack --dry-run` — tarball contains only `dist/{index,buildpack-registry,buildpack-registry-api}.{js,d.ts}`; no `dist/src/` or `dist/test/` entries.
4. `npm test` — all 10 tests pass; posttest `tsc -p test --noEmit` and `eslint` clean.
5. `node -e "const m = require('./dist/index.js'); console.log(Object.keys(m).sort().join(', '))"` — loads without error and prints `BuildpackRegistry` (this is the Node module resolution path that broke for CLI consumers).

## Related Issues
GitHub issue: heroku/cli#3810
